### PR TITLE
Attempt at fixing issues with celery beat

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 
 SERIES = 'latentcall'
 
-__version__ = '4.1.1-sl.2'
+__version__ = '4.1.1-sl.3'
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
 __homepage__ = 'http://celeryproject.org'

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1225,7 +1225,7 @@ class Celery(object):
 
     def uses_utc_timezone(self):
         """Check if the application uses the UTC timezone."""
-        return self.conf.timezone == 'UTC' or self.conf.timezone is None
+        return self.timezone == timezone.utc
 
     @cached_property
     def timezone(self):
@@ -1235,14 +1235,12 @@ class Celery(object):
         :setting:`timezone` setting.
         """
         conf = self.conf
-        tz = conf.timezone or 'UTC'
-        if not tz:
+        if not conf.timezone:
             if conf.enable_utc:
-                return timezone.get_timezone('UTC')
+                return timezone.utc
             else:
-                if not conf.timezone:
-                    return timezone.local
-        return timezone.get_timezone(tz)
+                return timezone.local
+        return timezone.get_timezone(conf.timezone)
 
 
 App = Celery  # noqa: E305 XXX compat

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -2,6 +2,7 @@
 """Actual App instance implementation."""
 from __future__ import absolute_import, unicode_literals
 
+from datetime import datetime
 import os
 import threading
 import warnings
@@ -31,6 +32,8 @@ from celery.utils import abstract
 from celery.utils.collections import AttributeDictMixin
 from celery.utils.dispatch import Signal
 from celery.utils.functional import first, head_from_fun, maybe_list
+from celery.utils.time import timezone, \
+    get_exponential_backoff_interval, to_utc
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
@@ -861,8 +864,8 @@ class Celery(object):
 
     def now(self):
         """Return the current time and date as a datetime."""
-        from datetime import datetime
-        return datetime.utcnow().replace(tzinfo=self.timezone)
+        now_in_utc = to_utc(datetime.utcnow())
+        return now_in_utc.astimezone(self.timezone)
 
     def select_queues(self, queues=None):
         """Select subset of queues.

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -209,6 +209,9 @@ def remaining(start, ends_in, now=None, relative=False):
         ~datetime.timedelta: Remaining time.
     """
     now = now or datetime.utcnow()
+    if now.utcoffset() != start.utcoffset():
+        # Timezone has changed, or DST started/ended
+        start = start.replace(tzinfo=now.tzinfo)
     end_date = start + ends_in
     if relative:
         end_date = delta_resolution(end_date, ends_in)

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -13,6 +13,7 @@ from kombu.utils.functional import reprcall
 from kombu.utils.objects import cached_property
 from pytz import AmbiguousTimeError, FixedOffset
 from pytz import timezone as _timezone
+from pytz import utc
 
 from celery.five import python_2_unicode_compatible, string_t
 
@@ -297,7 +298,10 @@ def make_aware(dt, tz):
 
 def localize(dt, tz):
     """Convert aware :class:`~datetime.datetime` to another timezone."""
-    dt = dt.astimezone(tz)
+    if is_naive(dt):  # Ensure timezone aware datetime
+        dt = make_aware(dt, tz)
+    if dt.tzinfo == utc:
+        dt = dt.astimezone(tz)  # Always safe to call astimezone on utc zones
     try:
         _normalize = tz.normalize
     except AttributeError:  # non-pytz tz

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 from datetime import datetime
+from time import time
 from weakref import ref
 
 from billiard.common import TERM_SIGNAME
@@ -20,7 +21,7 @@ from celery.app.trace import trace_task, trace_task_ret
 from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
                                SoftTimeLimitExceeded, TaskRevokedError,
                                Terminated, TimeLimitExceeded, WorkerLostError)
-from celery.five import python_2_unicode_compatible, string
+from celery.five import monotonic, python_2_unicode_compatible, string
 from celery.platforms import signals as _signals
 from celery.utils.functional import maybe, noop
 from celery.utils.log import get_logger
@@ -287,7 +288,8 @@ class Request(object):
     def on_accepted(self, pid, time_accepted):
         """Handler called when task is accepted by worker pool."""
         self.worker_pid = pid
-        self.time_start = time_accepted
+        # Convert monotonic time_accepted to absolute time
+        self.time_start = time() - (monotonic() - time_accepted)
         task_accepted(self)
         if not self.task.acks_late:
             self.acknowledge()

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -77,10 +77,10 @@ class test_App:
         tz_utc = timezone.get_timezone('UTC')
         tz_us_eastern = timezone.get_timezone(timezone_setting_value)
 
-        now = datetime.utcnow().replace(tzinfo=tz_utc)
+        now = to_utc(datetime.utcnow())
         app_now = self.app.now()
 
-        assert app_now.tzinfo == tz_utc
+        assert app_now.tzinfo is tz_utc
         assert app_now - now <= timedelta(seconds=1)
 
         # Check that timezone conversion is applied from configuration
@@ -90,7 +90,8 @@ class test_App:
         del self.app.timezone
 
         app_now = self.app.now()
-        assert app_now.tzinfo == tz_us_eastern
+
+        assert app_now.tzinfo.zone == tz_us_eastern.zone
 
         diff = to_utc(datetime.utcnow()) - localize(app_now, tz_utc)
         assert diff <= timedelta(seconds=1)
@@ -100,7 +101,7 @@ class test_App:
         del self.app.timezone
         app_now = self.app.now()
         assert self.app.timezone == tz_us_eastern
-        assert app_now.tzinfo == tz_us_eastern
+        assert app_now.tzinfo.zone == tz_us_eastern.zone
 
     @patch('celery.app.base.set_default_app')
     def test_set_default(self, set_default_app):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -824,17 +824,27 @@ class test_App:
 
     def test_timezone__none_set(self):
         self.app.conf.timezone = None
-        tz = self.app.timezone
-        assert tz == timezone.get_timezone('UTC')
+        self.app.conf.enable_utc = True
+        assert self.app.timezone == timezone.utc
+        del self.app.timezone
+        self.app.conf.enable_utc = False
+        assert self.app.timezone == timezone.local
 
     def test_uses_utc_timezone(self):
         self.app.conf.timezone = None
+        self.app.conf.enable_utc = True
         assert self.app.uses_utc_timezone() is True
 
+        self.app.conf.enable_utc = False
+        del self.app.timezone
+        assert self.app.uses_utc_timezone() is False
+
         self.app.conf.timezone = 'US/Eastern'
+        del self.app.timezone
         assert self.app.uses_utc_timezone() is False
 
         self.app.conf.timezone = 'UTC'
+        del self.app.timezone
         assert self.app.uses_utc_timezone() is True
 
     def test_compat_on_configure(self):

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import time
+import pytz
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pickle import dumps, loads
@@ -428,6 +429,40 @@ class test_crontab_remaining_estimate:
             datetime(2012, 2, 29, 14, 30),
         )
         assert next == datetime(2016, 2, 29, 14, 30)
+
+    def test_day_after_dst_end(self):
+        # Test for #1604 issue with region configuration using DST
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = pytz.timezone(tzname)
+        crontab = self.crontab(minute=0, hour=9)
+
+        # Set last_run_at Before DST end
+        last_run_at = tz.localize(datetime(2017, 10, 28, 9, 0))
+        # Set now after DST end
+        now = tz.localize(datetime(2017, 10, 29, 7, 0))
+        crontab.nowfun = lambda: now
+        next = now + crontab.remaining_estimate(last_run_at)
+
+        assert next.utcoffset().seconds == 3600
+        assert next == tz.localize(datetime(2017, 10, 29, 9, 0))
+
+    def test_day_after_dst_start(self):
+        # Test for #1604 issue with region configuration using DST
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = pytz.timezone(tzname)
+        crontab = self.crontab(minute=0, hour=9)
+
+        # Set last_run_at Before DST start
+        last_run_at = tz.localize(datetime(2017, 3, 25, 9, 0))
+        # Set now after DST start
+        now = tz.localize(datetime(2017, 3, 26, 7, 0))
+        crontab.nowfun = lambda: now
+        next = now + crontab.remaining_estimate(last_run_at)
+
+        assert next.utcoffset().seconds == 7200
+        assert next == tz.localize(datetime(2017, 3, 26, 9, 0))
 
 
 class test_crontab_is_due:

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -176,7 +176,12 @@ class test_make_aware:
 class test_localize:
 
     def test_tz_without_normalize(self):
-        tz = tzinfo()
+        class tzz(tzinfo):
+
+            def utcoffset(self, dt):
+                return None  # Mock no utcoffset specified
+
+        tz = tzz()
         assert not hasattr(tz, 'normalize')
         assert localize(make_aware(datetime.utcnow(), tz), tz)
 
@@ -184,6 +189,9 @@ class test_localize:
 
         class tzz(tzinfo):
             raises = None
+
+            def utcoffset(self, dt):
+                return None
 
             def normalize(self, dt, **kwargs):
                 self.normalized = True
@@ -207,6 +215,26 @@ class test_localize:
         localize(make_aware(datetime.utcnow(), tz3), tz3)
         assert tz3.normalized
         assert tz3.raised
+
+    def test_localize_changes_utc_dt(self):
+        now_utc_time = datetime.now(tz=pytz.utc)
+        local_tz = pytz.timezone('US/Eastern')
+        localized_time = localize(now_utc_time, local_tz)
+        assert localized_time == now_utc_time
+
+    def test_localize_aware_dt_idempotent(self):
+        t = (2017, 4, 23, 21, 36, 59, 0)
+        local_zone = pytz.timezone('America/New_York')
+        local_time = datetime(*t)
+        local_time_aware = datetime(*t, tzinfo=local_zone)
+        alternate_zone = pytz.timezone('America/Detroit')
+        localized_time = localize(local_time_aware, alternate_zone)
+        assert localized_time == local_time_aware
+        assert local_zone.utcoffset(
+            local_time) == alternate_zone.utcoffset(local_time)
+        localized_utc_offset = localized_time.tzinfo.utcoffset(local_time)
+        assert localized_utc_offset == alternate_zone.utcoffset(local_time)
+        assert localized_utc_offset == local_zone.utcoffset(local_time)
 
 
 @pytest.mark.parametrize('s,expected', [

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -7,6 +7,7 @@ import signal
 import socket
 import sys
 from datetime import datetime, timedelta
+from time import time
 
 import pytest
 from billiard.einfo import ExceptionInfo
@@ -515,6 +516,11 @@ class test_Request(RequestCase):
             assert not pool.terminate_job.call_count
             job.on_accepted(pid=314, time_accepted=monotonic())
             pool.terminate_job.assert_called_with(314, signum)
+
+    def test_on_accepted_time_start(self):
+        job = self.xRequest()
+        job.on_accepted(pid=os.getpid(), time_accepted=monotonic())
+        assert time() - job.time_start < 1
 
     def test_on_success_acks_early(self):
         job = self.xRequest()


### PR DESCRIPTION
We are on Celery 4.1.1 because upgrading to 4.1.2 gave us some problems. In an attempt to resolve the issue of tasks not being scheduled between 22:00-06:00, I've cherry picked all fixes related to Celery Beat and time stuff that were released in 4.1.2.

https://github.com/celery/celery/pull/4519
https://github.com/celery/celery/pull/3684
https://github.com/celery/celery/pull/4324
https://github.com/celery/celery/pull/4403
https://github.com/celery/celery/pull/4173

If this doesn't work, or we don't feel comfortable doing this, we can try using Celery 4.1.3.